### PR TITLE
Update rdkafka

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -566,9 +566,9 @@
       }
     },
     "node-rdkafka": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.7.3.tgz",
-      "integrity": "sha512-6ZSVNYvQi0mlXuZii7E5ifML+AsKAZGlXwELNw8MxqkjHfdGX/7JN2wqsIfzC5hYhLbPi+9HdZ1owA+N4Q9/ig==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.7.4.tgz",
+      "integrity": "sha512-415Hfu2SkAo9+mSj3xxw+dHwJqC0jRY0D/OKqUdPfvEE1r4p+N0OfbsAmmSR5FSxZFRFTY3j+/tGntp6ssqHWw==",
       "requires": {
         "bindings": "^1.3.1",
         "nan": "^2.14.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exp-kafka-listener",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exp-kafka-listener",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -547,7 +547,7 @@
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw="
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -566,9 +566,9 @@
       }
     },
     "node-rdkafka": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.7.1.tgz",
-      "integrity": "sha1-VFZi2cEFQYP8GDfDZvTZ5kfgDMU=",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.7.3.tgz",
+      "integrity": "sha512-6ZSVNYvQi0mlXuZii7E5ifML+AsKAZGlXwELNw8MxqkjHfdGX/7JN2wqsIfzC5hYhLbPi+9HdZ1owA+N4Q9/ig==",
       "requires": {
         "bindings": "^1.3.1",
         "nan": "^2.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exp-kafka-listener",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Simple stream-based kafka listener",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/BonnierNews/exp-kafka-listener#readme",
   "dependencies": {
-    "node-rdkafka": "^2.7.1"
+    "node-rdkafka": "^2.7.3"
   },
   "devDependencies": {
     "mocha": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple stream-based kafka listener",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Uppdatera kafka listenern.

Bumpa version av exp-kafka-listener till 0.1.3.

Detta borde göra att vi kan uppdatera carpenter till node 12.
Testerna är ostabila, och jag försökte förstå varför. Kör man dom individuellt fungerar de alltid, men `npm t` har något problem. Kunde dock inte lösa det.